### PR TITLE
Upgrade cabal and stack to newer versions

### DIFF
--- a/hvilken-lib.cabal
+++ b/hvilken-lib.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 3.0
 
 -- This file has been generated from package.yaml by hpack version 0.33.0.
 --
@@ -14,7 +14,7 @@ bug-reports:    https://github.com/cristeahub/hvilken/issues
 author:         Christoffer Tønnessen
 maintainer:     given@upon.request
 copyright:      2020 Christoffer Tønnessen
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,8 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.16
+resolver:
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/12.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,8 @@ packages:
     hackage: dates-0.2.3.0@sha256:915a2fc85ea818542851ed54a85abe6a042e7d78f470a5a6db032768f6c6415a,2179
 snapshots:
 - completed:
-    size: 532380
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/16.yaml
-    sha256: d6b004b095fe2a0b8b14fbc30014ee97e58843b9c9362ddb9244273dda62649e
-  original: lts-16.16
+    size: 586041
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/12.yaml
+    sha256: 80fc6391195ff00c36f2a605ecbb07de909bfaa2eaa9722a27e486a6ecf8ecb0
+  original:
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/12.yaml


### PR DESCRIPTION
These are much newer than the old versions for this tool.
